### PR TITLE
feat: generate v1_html and v1_json files for simple index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 simple/
 local.json
 local.db
+local.db.serial
 plan.json
 remote.json
 venv/

--- a/shadowmire.py
+++ b/shadowmire.py
@@ -844,8 +844,8 @@ class SyncBase:
         # always link index.html to index.v1_html
         html_simple_path = self.basedir / "simple" / "index.html"
         if not html_simple_path.is_symlink():
-                html_simple_path.unlink(missing_ok=True)
-                html_simple_path.symlink_to("index.v1_html")
+            html_simple_path.unlink(missing_ok=True)
+            html_simple_path.symlink_to("index.v1_html")
 
         # generate v1_json index and local.db{,.serial} for downstream use
         v1_json_index_path = self.basedir / "simple" / "index.v1_json"
@@ -971,7 +971,7 @@ class SyncPyPI(SyncBase):
             json.dump(self.remote_packages, f)
             logger.info("File saved to remote.json.")
         return self.last_serial, self.remote_packages
-    
+
     def get_package_metadata(self, package_name: str) -> dict:
         return self.pypi.get_package_metadata(package_name)
 
@@ -1119,7 +1119,7 @@ class SyncPlainHTTP(SyncBase):
             json.dump(remote_pkgs, f)
             logger.info("File saved to remote.json.")
         return serial, remote_pkgs
-    
+
     def get_package_metadata(self, package_name: str) -> dict:
         file_url = urljoin(self.upstream, f"json/{package_name}")
         success, resp = download(

--- a/shadowmire.py
+++ b/shadowmire.py
@@ -36,6 +36,9 @@ logger = logging.getLogger("shadowmire")
 
 
 USER_AGENT = "Shadowmire (https://github.com/taoky/shadowmire)"
+LOCAL_DB_NAME = "local.db"
+LOCAL_JSON_NAME = "local.json"
+LOCAL_DB_SERIAL_NAME = "local.db.serial"
 
 # Note that it's suggested to use only 3 workers for PyPI.
 WORKERS = int(os.environ.get("SHADOWMIRE_WORKERS", "3"))
@@ -450,6 +453,7 @@ class PyPI:
             "files": [],
             "meta": {
                 "api-version": "1.1",
+                # not required by PEP691, but bandersnatch has it
                 "_last-serial": str(package_meta["last_serial"]),
             },
             "name": package_meta["info"]["name"],
@@ -486,6 +490,7 @@ ShadowmirePackageItem = tuple[str, int]
 class Plan:
     remove: list[str]
     update: list[str]
+    remote_last_serial: int
 
 
 def match_patterns(
@@ -535,15 +540,15 @@ class SyncBase:
         """
         local should NOT skip invalid (-1) serials
         """
-        remote = self.fetch_remote_versions()
-        remote = self.filter_remote_with_excludes(remote, excludes)
+        remote_sn, remote_pkgs = self.fetch_remote_versions()
+        remote_pkgs = self.filter_remote_with_excludes(remote_pkgs, excludes)
         with open(self.basedir / "remote_excluded.json", "w") as f:
-            json.dump(remote, f)
+            json.dump(remote_pkgs, f)
 
         to_remove = []
         to_update = []
         local_keys = set(local.keys())
-        remote_keys = set(remote.keys())
+        remote_keys = set(remote_pkgs.keys())
         for i in local_keys - remote_keys:
             to_remove.append(i)
             local_keys.remove(i)
@@ -566,17 +571,18 @@ class SyncBase:
             to_update.append(i)
         for i in local_keys:
             local_serial = local[i]
-            remote_serial = remote[i]
+            remote_serial = remote_pkgs[i]
             if local_serial != remote_serial:
                 if local_serial == -1:
                     logger.info("skip %s, as it's marked as not exist at upstream", i)
                     to_remove.append(i)
                 else:
                     to_update.append(i)
-        output = Plan(remove=to_remove, update=to_update)
+        output = Plan(remove=to_remove, update=to_update, remote_last_serial=remote_sn)
         return output
 
-    def fetch_remote_versions(self) -> dict[str, int]:
+    def fetch_remote_versions(self) -> tuple[int, dict[str, int]]:
+        # returns (last_serial, {package_name: serial, ...})
         raise NotImplementedError
 
     def get_package_metadata(self, package_name: str) -> dict:
@@ -816,12 +822,12 @@ class SyncBase:
                 index_html_path.unlink()
             index_html_path.symlink_to("index.v1_html")
 
-    def finalize(self) -> None:
+    def finalize(self, index_serial: int) -> None:
         local_names = self.local_db.keys()
-        # generate index.html at basedir
-        index_path = self.basedir / "simple" / "index.html"
+        # generate v1_html index
+        v1_html_index_path = self.basedir / "simple" / "index.v1_html"
         # modified from bandersnatch
-        with overwrite(index_path) as f:
+        with overwrite(v1_html_index_path) as f:
             f.write("<!DOCTYPE html>\n")
             f.write("<html>\n")
             f.write("  <head>\n")
@@ -835,6 +841,25 @@ class SyncBase:
                 # We're really trusty that this is all encoded in UTF-8. :/
                 f.write(f'    <a href="{pkg}/">{pkg}</a><br/>\n')
             f.write("  </body>\n</html>")
+        # always link index.html to index.v1_html
+        html_simple_path = self.basedir / "simple" / "index.html"
+        if not html_simple_path.is_symlink():
+                html_simple_path.unlink(missing_ok=True)
+                html_simple_path.symlink_to("index.v1_html")
+
+        # generate v1_json index and local.db{,.serial} for downstream use
+        v1_json_index_path = self.basedir / "simple" / "index.v1_json"
+        with overwrite(v1_json_index_path) as f:
+            index_json: dict[str, Any] = {
+                "meta": {
+                    "api-version": "1.1",
+                    "_last-serial": index_serial,
+                },
+                "projects": [{"name": n} for n in sorted(local_names)],
+            }
+            json.dump(index_json, f)
+        with overwrite(self.basedir / LOCAL_DB_SERIAL_NAME) as f:
+            f.write(str(index_serial))
         self.local_db.dump_json()
 
     def skip_this_package(self, i: dict, dest: Path) -> bool:
@@ -938,14 +963,14 @@ class SyncPyPI(SyncBase):
         self.remote_packages: Optional[dict[str, int]] = None
         super().__init__(basedir, local_db, sync_packages)
 
-    def fetch_remote_versions(self) -> dict[str, int]:
+    def fetch_remote_versions(self) -> tuple[int, dict[str, int]]:
         self.last_serial = self.pypi.changelog_last_serial()
         self.remote_packages = self.pypi.list_packages_with_serial()
         logger.info("Remote has %s packages", len(self.remote_packages))
         with overwrite(self.basedir / "remote.json") as f:
             json.dump(self.remote_packages, f)
             logger.info("File saved to remote.json.")
-        return self.remote_packages
+        return self.last_serial, self.remote_packages
     
     def get_package_metadata(self, package_name: str) -> dict:
         return self.pypi.get_package_metadata(package_name)
@@ -1066,20 +1091,34 @@ class SyncPlainHTTP(SyncBase):
             self.pypi = None
         super().__init__(basedir, local_db, sync_packages)
 
-    def fetch_remote_versions(self) -> dict[str, int]:
-        remote: dict[str, int]
+    def fetch_remote_versions(self) -> tuple[int, dict[str, int]]:
+        remote_pkgs: dict[str, int]
         if not self.pypi:
-            remote_url = urljoin(self.upstream, "local.json")
-            resp = self.session.get(remote_url)
+            remote_pkg_db_url = urljoin(self.upstream, LOCAL_JSON_NAME)
+            resp = self.session.get(remote_pkg_db_url)
             resp.raise_for_status()
-            remote = resp.json()
+            remote_pkgs = resp.json()
+            # first fallback to max serial in remote_pkgs
+            serial = max(remote_pkgs.values()) if remote_pkgs else -1
+            # then try to get last serial from remote
+            remote_last_serial_url = urljoin(self.upstream, LOCAL_DB_SERIAL_NAME)
+            try:
+                resp = self.session.get(remote_last_serial_url)
+                resp.raise_for_status()
+                serial = int(resp.text.strip())
+            except (requests.RequestException, ValueError):
+                logger.warning(
+                    f"cannot get last_serial from upstream, fallback to max package serial in {LOCAL_JSON_NAME}",
+                    exc_info=True,
+                )
         else:
-            remote = self.pypi.list_packages_with_serial()
-        logger.info("Remote has %s packages", len(remote))
+            serial = self.pypi.changelog_last_serial()
+            remote_pkgs = self.pypi.list_packages_with_serial()
+        logger.info("Remote has %s packages", len(remote_pkgs))
         with overwrite(self.basedir / "remote.json") as f:
-            json.dump(remote, f)
+            json.dump(remote_pkgs, f)
             logger.info("File saved to remote.json.")
-        return remote
+        return serial, remote_pkgs
     
     def get_package_metadata(self, package_name: str) -> dict:
         file_url = urljoin(self.upstream, f"json/{package_name}")
@@ -1276,8 +1315,7 @@ def cli(ctx: click.Context, repo: str) -> None:
 
     # Make sure basedir is absolute
     basedir = Path(repo).resolve()
-    local_db = LocalVersionKV(basedir / "local.db", basedir / "local.json")
-
+    local_db = LocalVersionKV(basedir / LOCAL_DB_NAME, basedir / LOCAL_JSON_NAME)
     ctx.obj["basedir"] = basedir
     ctx.obj["local_db"] = local_db
 
@@ -1335,7 +1373,7 @@ def sync(
     with overwrite(basedir / "plan.json") as f:
         json.dump(plan, f, default=vars, indent=2)
     success = syncer.do_sync_plan(plan, prerelease_excludes, excluded_wheel_filenames)
-    syncer.finalize()
+    syncer.finalize(plan.remote_last_serial)
 
     logger.info("Synchronization finished. Success: %s", success)
 
@@ -1500,7 +1538,7 @@ def verify(
         packages_pathcache,
         compare_size,
     )
-    syncer.finalize()
+    syncer.finalize(plan.remote_last_serial)
 
     logger.info(
         "====== Step 5. Remove any unreferenced files in `packages` folder ======"


### PR DESCRIPTION
This change involves the generation of a new file `local.db.serial`, which records the last changelog serial of the latest successful shadowmire synchronization or verification. This is useful to be used in `simple/index.v1_json` in the `meta` field, and for general debugging purposes without downloading the full `local.db`.

Shadowmire retrieves this serial from (in order):

- PyPI XMLRPC call if upstream is PyPI
- remote `local.db.serial` if upstream is shadowmire
- (best-effort guess) max package serial (before filtering out anything) from `local.json` if upstream is shadowmire but `local.db.serial` does not exist or is not valid