### PR TITLE
feat: make include patterns have higher priority than exclude pattern.

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -9,7 +9,8 @@ sync_packages = true
 exclude = [
     "^[a-z]"
 ]
-# When include has values, exclude is ignored
+# Include patterns have higher priority than exclude patterns.
+# Packages matching include patterns will be included even if they also match exclude patterns.
 # include = ["^requests$"]
 prerelease_exclude = [
     ".+"

--- a/shadowmire.py
+++ b/shadowmire.py
@@ -567,15 +567,16 @@ class PackageInclusionChecker:
         return bool(self.excludes or self.includes)
 
     def is_included(self, package_name: str) -> bool:
-        # If package matches include pattern, include it regardless of exclude patterns
+        if not self.has_rules():
+            return True
+
         if self.includes and match_patterns(package_name, self.includes):
             return True
-        
-            # Ignore excludes if includes are specified
+
         if self.excludes and match_patterns(package_name, self.excludes):
             return False
-        
-        return True # Default to include if no patterns matched
+
+        return not self.includes
 
 
 class FileInclusionChecker:

--- a/shadowmire.py
+++ b/shadowmire.py
@@ -567,13 +567,15 @@ class PackageInclusionChecker:
         return bool(self.excludes or self.includes)
 
     def is_included(self, package_name: str) -> bool:
-        if not self.has_rules():
+        # If package matches include pattern, include it regardless of exclude patterns
+        if self.includes and match_patterns(package_name, self.includes):
             return True
-        if self.includes:
+        
             # Ignore excludes if includes are specified
-            return match_patterns(package_name, self.includes)
-        else:
-            return not match_patterns(package_name, self.excludes)
+        if self.excludes and match_patterns(package_name, self.excludes):
+            return False
+        
+        return True # Default to include if no patterns matched
 
 
 class FileInclusionChecker:


### PR DESCRIPTION
In this case, exclude pattern could have much larger range and some specific important packages in that range will not be excluded. This may easier exclude patterns for large local mirror.

Happy to hear any better suggestions.